### PR TITLE
Upgrade key dependencies to latest stable versions

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,27 @@ const config = {
       name: "@storybook/react-webpack5",
       options: {},
     },
+    babel: async (options) => {
+      options.presets = options.presets || [];
+      options.presets.push(["@babel/preset-react", { runtime: "automatic" }]);
+      return options;
+    },
+    webpackFinal: async (config) => {
+      config.module.rules.push({
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: [
+              ["@babel/preset-env", { targets: "defaults" }],
+              ["@babel/preset-react", { runtime: "automatic" }]
+            ]
+          }
+        }
+      });
+      return config;
+    },
     docs: {
       autodocs: "tag",
     },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "dependencies": {
         "gh-pages": "^6.0.0",
         "prop-types": "^15.8.1",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-router-dom": "^6.8.1",
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2",
         "react-twitter-embed": "^4.0.4"
     },
     "devDependencies": {
@@ -25,17 +25,17 @@
         "@babel/preset-env": "^7.21.4",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.21.4",
-        "@storybook/addon-essentials": "7.0.3",
-        "@storybook/addon-interactions": "7.0.3",
-        "@storybook/addon-links": "7.0.3",
-        "@storybook/blocks": "7.0.3",
-        "@storybook/react": "7.0.3",
-        "@storybook/react-webpack5": "7.0.3",
-        "@storybook/testing-library": "0.2.0",
-        "htmlnano": "2.0.3",
+        "@storybook/addon-essentials": "^8.6.14",
+        "@storybook/addon-interactions": "^8.6.14",
+        "@storybook/addon-links": "^8.6.14",
+        "@storybook/blocks": "^8.6.14",
+        "@storybook/react": "^8.6.14",
+        "@storybook/react-webpack5": "^8.6.14",
+        "@storybook/testing-library": "^0.2.2",
+        "htmlnano": "^2.1.2",
         "parcel": "^2.8.0",
         "parcel-reporter-static-files-copy": "^1.5.0",
         "process": "^0.11.10",
-        "storybook": "7.0.3"
+        "storybook": "^8.6.14"
     }
 }


### PR DESCRIPTION
- React: 18.2.0 → 19.1.1
- React-DOM: 18.2.0 → 19.1.1
- React Router DOM: 6.8.1 → 7.8.2
- Storybook packages: 7.0.3 → 8.6.14
- htmlnano: 2.0.3 → 2.1.2
- @storybook/testing-library: 0.2.0 → 0.2.2

Updated Storybook configuration with explicit Babel setup for React 19 compatibility. Build and deployment functionality verified and working.

🤖 Generated with [Claude Code](https://claude.ai/code)