### PR TITLE
Add automated GitHub Pages deployment via GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the already in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build
+        run: npm run build
+        
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ npm run build
 
 #### Deploying the project
 
+**Automatic Deployment:** The website automatically deploys to GitHub Pages when changes are pushed to the `main` branch via GitHub Actions.
+
+**Manual Deployment (if needed):**
 ```shell
-npm run deploy
+npm run deploy:manual
 ```
 
-This also publishes the changes to Github Pages. See [package.json](package.json) for configuring the Github Pages link.
+See [package.json](package.json) for configuring the GitHub Pages link.
 
 ## Storybook
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
     "source": "./index.html",
     "homepage": "https://harkanwalpsingh.github.io/portfolio-website",
     "scripts": {
-        "predeploy": "npm run build",
-        "deploy": "gh-pages -d dist",
         "build": "parcel build --public-url ./ --no-scope-hoist",
         "dev": "parcel",
         "storybook": "storybook dev -p 6006",
-        "build-storybook": "storybook build"
+        "build-storybook": "storybook build",
+        "deploy:manual": "npm run build && gh-pages -d dist"
     },
     "dependencies": {
         "gh-pages": "^6.0.0",


### PR DESCRIPTION
- Created GitHub Actions workflow that deploys on push to main branch
- Removed manual deploy script and replaced with deploy:manual for emergency use
- Updated README to reflect automated deployment process
- Build and deployment will now happen automatically when PRs are merged

This eliminates the need for manual deployment steps and ensures consistent deployments with proper CI/CD practices.

🤖 Generated with [Claude Code](https://claude.ai/code)