### PR TITLE
Remove Philosophy and Let's Connect sections from About page

### DIFF
--- a/content/pages/about.mdx
+++ b/content/pages/about.mdx
@@ -61,26 +61,6 @@ My work has been recognized across all organizations where I've contributed:
 - Strong foundation in engineering principles
 - Developed analytical thinking and problem-solving skills
 
-## Philosophy
-
-I believe in building systems that deliver both **technical excellence** and **business impact**:
-
-> **Performance at Scale** - Every optimization should consider both immediate gains and long-term scalability.
-
-> **Privacy by Design** - In today's data-driven world, privacy and compliance must be foundational, not afterthoughts.
-
-> **Cost-Conscious Engineering** - Great engineering considers not just functionality but also operational costs and resource efficiency.
-
-> **Continuous Innovation** - Staying current with emerging technologies while maintaining proven system reliability.
-
-## Let's Connect
-
-I'm always excited to discuss challenging technical problems, system architecture, performance optimization, or explore new opportunities. Whether you have a complex scaling challenge, want to discuss privacy-compliant architectures, or are interested in collaboration, feel free to reach out!
-
-- 💼 [LinkedIn](https://www.linkedin.com/in/harkanwalpsingh/)
-- 🐙 [GitHub](https://github.com/HarkanwalPSingh) 
-- 📧 [Email](mailto:harkanwal.p.singh@gmail.com)
-- 🐦 [Twitter](https://twitter.com/factbot_cereal)
 
 ---
 


### PR DESCRIPTION
Fixes #11 by removing:
- Philosophy section with engineering principles
- Let's Connect section with social media links

🤖 Generated with [Claude Code](https://claude.ai/code)